### PR TITLE
✨ support arbitrary auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Attributes section.
 - `height` (optional, default = `"0"`): the height of the canvas for agent animation
   - The animation will always take up a (roughly) square area, so this should typically be the same
     value as `width`.
+- `auth-scheme` (optional, default = `"bearer"`): the auth scheme to use with your token
+  - `bearer` is what you want with the Deepgram API, to work with token-based auth. You may find it
+    more convenient to use an API key (`token` scheme) for local dev. But never use API keys in
+    a production browser application!
 - `url` (required): The API url
   - Chances are you'll set this to `"https://api.deepgram.com/v1/agent"`!
 - `idle-timeout-ms` (optional): how long to wait for user idleness before closing the socket
@@ -72,7 +76,11 @@ Attributes section.
 
 ### Properties
 
-- `apiKey` (required): the key to use for accessing the Deepgram /agent API.
+- `token` (optional): the token to use for accessing the Deepgram /agent API. See the [token-based
+  auth docs](https://developers.deepgram.com/reference/token-based-auth-api/grant-token) for how to
+  create safe-for-browser tokens.
+  - If not provided, the `auth-scheme` will also be ignored. Only makes sense if your API URL is
+    unauthenticated.
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Attributes section.
   - The animation will always take up a (roughly) square area, so this should typically be the same
     value as `width`.
 - `auth-scheme` (optional, default = `"bearer"`): the auth scheme to use with your token
-  - `bearer` is what you want with the Deepgram API, to work with token-based auth. You may find it
-    more convenient to use an API key (`token` scheme) for local dev. But never use API keys in
-    a production browser application!
+  - Use `bearer` for the Deepgram API when working with token-based authentication. For local
+    development you may find it more convenient to use an API key (`token` scheme). **Never use API
+    keys in a production browser application!**
 - `url` (required): The API url
   - Chances are you'll set this to `"https://api.deepgram.com/v1/agent"`!
 - `idle-timeout-ms` (optional): how long to wait for user idleness before closing the socket
@@ -89,9 +89,10 @@ to run into some than others.
 
 #### Common events
 
-- `"no key"`: emitted when trying to connect and API key is missing
 - `"no url"`: emitted when trying to connect and API url is missing
 - `"no config"`: emitted when trying to connect and config is missing
+- `"invalid auth"`: emitted when trying to connect and the WebSocket rejects the auth scheme or
+  token
 - `"socket open"`: socket successfully opened
 - `"socket close"`: socket successfully closed
 - `"connection timeout"`: socket failed to connect due to a timeout (10s)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Attributes section.
 ### Properties
 
 - `token` (optional): the token to use for accessing the Deepgram /agent API. See the [token-based
-  auth docs](https://developers.deepgram.com/reference/token-based-auth-api/grant-token) for how to
+  auth docs](https://developers.deepgram.com/guides/fundamentals/token-based-authentication) for how to
   create safe-for-browser tokens.
   - If not provided, the `auth-scheme` will also be ignored. Only makes sense if your API URL is
     unauthenticated.

--- a/example/index.html
+++ b/example/index.html
@@ -23,6 +23,7 @@
       url="wss://agent.deepgram.com/v1/agent/converse"
       idle-timeout-ms="30000"
       output-sample-rate="48000"
+      auth-scheme="token"
     ></deepgram-agent>
     <button id="run">Run</button>
     <h2>deepgram-hoop (standalone animation)</h2>

--- a/example/setup.ts
+++ b/example/setup.ts
@@ -1,7 +1,7 @@
 import { AgentElement } from "../src";
 
 const agent = document.getElementById("agent") as AgentElement;
-agent.apiKey = API_KEY;
+agent.token = API_KEY;
 document.getElementById("run")?.addEventListener("click", function run() {
   if (agent.getAttribute("config")) {
     agent.removeAttribute("config");
@@ -15,6 +15,11 @@ document.getElementById("run")?.addEventListener("click", function run() {
       console.error(detail);
       agent.removeAttribute("config");
     }
+  });
+
+  agent.addEventListener("invalid auth", (message) => {
+    const { detail = {} } = message as CustomEvent;
+    console.error("Invalid auth.", detail);
   });
 });
 


### PR DESCRIPTION
The primary use case here is just to enable token-based auth, which should be the default choice. But also, if you can point at an arbitrary API url, you probably also want arbitrary and optional auth control!